### PR TITLE
NUT 2.8 fixes

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,24 @@
+2023-08-13  Jim Klimov <jimklimov@gmail.com>
+	* wmnut-0.68:
+
+	  + Numerous documentation updates (building, spelling...)
+	  + CI: CodeQL workflow for code scanning
+	  + Build recipe updates to match NUT v2.8.0 public API changes
+	    (note: not cleanly compatible with older NUT releases anymore)
+	  + contrib/wmnut.desktop: Add categories and keywords to .desktop file
+	  + configure.ac: Fix obsolete autoconf usages
+
+2021-12-06  Arnaud Quette  <arnaud.quette@free.fr>
+	* wmnut-0.67:
+
+	  + Clear battery load 10's column
+	  + configure.ac: Don't set `LDFLAGS` in configure.ac
+	  + contrib/wmnut.desktop: Add a `Comment` entry
+	  + wmnut assumes that there is a UPS available and
+	    seg-faults if not. Now just exit with an err message
+	    unless there is at least one host.
+	  + Remove duplicate variable definition (wmgeneral, display)
+
 2016-12-23  Arnaud Quette  <arnaud.quette@free.fr>
 	* wmnut-0.66:
 

--- a/configure.ac
+++ b/configure.ac
@@ -118,7 +118,7 @@ dnl ===============================================
 dnl Checks for NUT client library
 dnl ===============================================
 
-PKG_CHECK_MODULES(NUT, libupsclient  >= 2.4.0)
+PKG_CHECK_MODULES(NUT, libupsclient  >= 2.8.0)
 NUT_HEADER="$NUT_CFLAGS"
 NUT_LIB="$NUT_LIBS"
 

--- a/configure.ac
+++ b/configure.ac
@@ -8,7 +8,7 @@ AC_CANONICAL_TARGET
 AC_CONFIG_SRCDIR(src/wmnut.c)
 AM_INIT_AUTOMAKE
 
-AM_CONFIG_HEADER(config.h)
+AC_CONFIG_HEADERS([config.h])
 
 dnl Checks for programs.
 AC_PROG_INSTALL
@@ -137,14 +137,8 @@ AC_SUBST(NUT_HEADER)
 AC_SUBST(NUT_LIB)
 
 dnl Checks for header files.
-AC_HEADER_STDC
 AC_HEADER_SYS_WAIT
-AC_HEADER_TIME
 AC_CHECK_HEADERS(unistd.h stdlib.h stdio.h string.h signal.h ctype.h stdarg.h X11/Xlib.h X11/xpm.h X11/extensions/shape.h X11/Xatom.h)
-
-dnl Checks for header files.
-AC_HEADER_STDC
-
 
 dnl Checks for library functions.
 dnl AC_FUNC_MALLOC

--- a/configure.ac
+++ b/configure.ac
@@ -2,7 +2,7 @@ dnl ====================================================================
 dnl | WMNut: configure.ac                                              |
 dnl ====================================================================
 
-AC_INIT([wmnut],[0.67])
+AC_INIT([wmnut],[0.68])
 AC_CANONICAL_HOST
 AC_CANONICAL_TARGET
 AC_CONFIG_SRCDIR(src/wmnut.c)

--- a/configure.ac
+++ b/configure.ac
@@ -94,9 +94,9 @@ dnl =========
 AC_ARG_ENABLE(debug,
              [  --enable-debug          turn on debugging [default=no]],, enable_debug=no)
 if test "$enable_debug" = yes; then
-  DFLAGS="-Wall -g -ansi -pedantic"
+  DBGFLAGS="-Wall -g -ansi -pedantic"
 fi
-AC_SUBST(DFLAGS)
+AC_SUBST([DBGFLAGS])
 
 
 dnl ===============

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -15,7 +15,7 @@ AM_CFLAGS =  \
 	@HEADER_SEARCH_PATH@ \
 	@NUT_HEADER@ \
 	@XCFLAGS@ \
-	@DFLAGS@ \
+	@DBGFLAGS@ \
 	@CFLAGS@
 
 wmnut_LDADD = \

--- a/src/wmgeneral.h
+++ b/src/wmgeneral.h
@@ -1,14 +1,14 @@
 #ifndef WMGENERAL_H_INCLUDED
 #define WMGENERAL_H_INCLUDED
 
+#ifdef HAVE_CONFIG_H
+	#include "config.h"
+#endif
+
 /* X11 includes */
 #include <X11/X.h>
 #include <X11/xpm.h>
 #include <string.h>
-
-#ifdef HAVE_CONFIG_H
-	#include "config.h"
-#endif
 
   /***********/
  /* Defines */

--- a/src/wmnut.h
+++ b/src/wmnut.h
@@ -89,7 +89,7 @@ typedef struct ups_info {
   char       *upsname;
   char       *hostname;
   UPSCONN_t  connexion;
-  int        port;
+  uint16_t   port;
   int        ups_status;	/* -1 if not init'ed */
   int        comm_status;	/* -1 if not init'ed, -2 if not available  */
   int        battery_percentage;/* -1 if not init'ed, -2 if not available  */

--- a/src/wmnut.h
+++ b/src/wmnut.h
@@ -21,6 +21,10 @@
  *
  */
 
+#ifdef HAVE_CONFIG_H
+	#include "config.h"
+#endif
+
 /* standard system includes */
 #ifdef FreeBSD
  #include <err.h>
@@ -40,10 +44,6 @@
 /* nut and wmnut includes */
 #include <upsclient.h>
 #include "wmgeneral.h"
-
-#ifdef HAVE_CONFIG_H
-	#include "config.h"
-#endif
 
 /* pixmaps */
 #include "wmnut_master.xpm"


### PR DESCRIPTION
Patches 1 and 2 are unrelated autotools updates.
Patches 3 and 4 fix build failures against libupsclient 2.8.0.
Patch 5 bumps the minimum required version of libupsclient to 2.8.0, since the changes made to support it are not backward-compatible.