### PR TITLE
Rename `bool` union member

### DIFF
--- a/src/rcfiles.c
+++ b/src/rcfiles.c
@@ -112,10 +112,7 @@ void ParseRCFile(const char *filename, rckeys *keys)
 									AddHost(p);
 								break;
 							case TYPE_BOOL:
-								if (!strncmp(p, "on", 2))
-									*keys[key].var.bool = 1;
-								else
-									*keys[key].var.bool = 0;
+								*keys[key].var.boolean = strncmp(p, "on", 2) == 0;
 								break;
 							case TYPE_INT:
 								*keys[key].var.integer = atoi(p);

--- a/src/wmgeneral.h
+++ b/src/wmgeneral.h
@@ -35,7 +35,7 @@ union var {
 	int	*integer;
 	float	*floater;
 	char	*str;
-	int	*bool;
+	int	*boolean;
 };
 
 typedef struct {


### PR DESCRIPTION
In C23, `bool` has been changed from a macro defined in `<stdbool.h>`, which expands to `_Bool`, to a keyword.  The `var` union defined in wmgeneral.h contains a member named `bool`, which is, therefore, not compatible with C23. The next version of gcc defaults to C23, and so this union member will cause compilation to fail.  Rename it to `boolean`.

Replace `if (cond) { x = 1; } else { x = 0; }` with `x = cond;`