### PR TITLE
Potential fix for code scanning alert no. 37: Local variable hides global variable

### DIFF
--- a/src/wmgeneral.c
+++ b/src/wmgeneral.c
@@ -121,17 +121,17 @@ void SetWindowName(char *name) {
 /*******************************************************************************\
 |* GetXPM                                                                      *|
 \*******************************************************************************/
-static void GetXPM(XpmIcon *wmgen, char *pixmap_bytes[]) {
+static void GetXPM(XpmIcon *icon, char *pixmap_bytes[]) {
 	XWindowAttributes	attributes;
 	int	err;
 
 	/* For the colormap */
 	XGetWindowAttributes(display, Root, &attributes);
 
-	wmgen->attributes.valuemask |= (XpmReturnPixels | XpmReturnExtensions);
+	icon->attributes.valuemask |= (XpmReturnPixels | XpmReturnExtensions);
 
-	err = XpmCreatePixmapFromData(display, Root, pixmap_bytes, &(wmgen->pixmap),
-					&(wmgen->mask), &(wmgen->attributes));
+	err = XpmCreatePixmapFromData(display, Root, pixmap_bytes, &(icon->pixmap),
+					&(icon->mask), &(icon->attributes));
 
 	if (err != XpmSuccess) {
 		fprintf(stderr, "Not enough free colorcells.\n");


### PR DESCRIPTION
Potential fix for [https://github.com/networkupstools/wmnut/security/code-scanning/37](https://github.com/networkupstools/wmnut/security/code-scanning/37)

To resolve the issue, we will rename the parameter `wmgen` in the `GetXPM` function to a distinct name, such as `icon`. This ensures that the local parameter does not hide the global variable `wmgen`. The change will be limited to the function's parameter declaration and its usage within the function body.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
