### PR TITLE
Potential fix for code scanning alert no. 36: Unbounded write

### DIFF
--- a/src/wmnut.c
+++ b/src/wmnut.c
@@ -769,7 +769,7 @@ int AddHost(char *hostname)
 
 				DEBUGOUT("%s: %s\n", hostname, answer[1]);
 
-				sprintf(newhostname, "%s@%s", answer[1], hostname);
+				snprintf(newhostname, sizeof(newhostname), "%s@%s", answer[1], hostname);
 				if (AddHost(newhostname)) {
 					/* break; */
 					newhostname[0] = '\0';


### PR DESCRIPTION
Potential fix for [https://github.com/networkupstools/wmnut/security/code-scanning/36](https://github.com/networkupstools/wmnut/security/code-scanning/36)

To fix the issue, the `sprintf` call should be replaced with `snprintf`, which allows specifying the maximum size of the destination buffer. This ensures that the concatenated string does not exceed the size of `newhostname`. The fix involves:
1. Replacing `sprintf` with `snprintf` on line 772 in `src/wmnut.c`.
2. Specifying the size of `newhostname` (32 bytes) as the maximum length for the `snprintf` operation.
3. Ensuring that the resulting string is null-terminated and does not overflow the buffer.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
