### PR TITLE
Potential fix for code scanning alert no. 35: Unbounded write

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -175,7 +175,25 @@ AC_SUBST(NUT_VERSION)
 
 dnl Checks for header files.
 AC_HEADER_SYS_WAIT
-AC_CHECK_HEADERS(unistd.h stdlib.h stdio.h string.h signal.h ctype.h stdarg.h X11/X.h X11/Xlib.h X11/xpm.h X11/extensions/shape.h X11/Xatom.h)
+
+AC_CHECK_HEADER([limits.h],
+    [AC_DEFINE([HAVE_LIMITS_H], [1],
+        [Define to 1 if you have <limits.h>.])])
+
+AC_CHECK_HEADER([stdlib.h],
+    [AC_DEFINE([HAVE_STDLIB_H], [1],
+        [Define to 1 if you have <stdlib.h>.])])
+
+AC_CHECK_DECLS(realpath, [], [],
+[#ifdef HAVE_LIMITS_H
+# include <limits.h>
+#endif
+#ifdef HAVE_STDLIB_H
+# include <stdlib.h>
+#endif
+])
+
+AC_CHECK_HEADERS(unistd.h stdio.h string.h signal.h ctype.h stdarg.h X11/X.h X11/Xlib.h X11/xpm.h X11/extensions/shape.h X11/Xatom.h)
 
 dnl Checks for library functions.
 dnl AC_FUNC_MALLOC

--- a/src/rcfiles.c
+++ b/src/rcfiles.c
@@ -146,7 +146,11 @@ void LoadRCFile(rckeys *keys)
 	ParseRCFile(MAINRC_FILE, keys);
 
 	p = getenv("HOME");
-	sprintf(home_file, "%s/%s", p, RC_FILE);
+	if (p) {
+		snprintf(home_file, sizeof(home_file), "%s/%s", p, RC_FILE);
+	} else {
+		home_file[0] = '\0'; // Ensure home_file is empty if HOME is not set
+	}
 	ParseRCFile(home_file, keys);
 }
 

--- a/src/rcfiles.c
+++ b/src/rcfiles.c
@@ -136,7 +136,7 @@ void ParseRCFile(const char *filename, rckeys *keys)
 \*******************************************************************************/
 void LoadRCFile(rckeys *keys)
 {
-	char	home_file[128];
+	char	home_file[128];	/* FIXME with PATH_MAX or equivalents, portably */
 	char	*p;
 
 #ifdef DEBUG
@@ -146,11 +146,21 @@ void LoadRCFile(rckeys *keys)
 	ParseRCFile(MAINRC_FILE, keys);
 
 	p = getenv("HOME");
+	home_file[0] = '\0';
 	if (p) {
-		snprintf(home_file, sizeof(home_file), "%s/%s", p, RC_FILE);
-		ParseRCFile(home_file, keys);
-	} else {
-		home_file[0] = '\0'; // Ensure home_file is empty if HOME is not set
+#ifdef HAVE_REALPATH && HAVE_REALPATH
+		char resolved_path[PATH_MAX];
+		if (realpath(p, resolved_path))
+			p = resolved_path;
+		else
+			p = NULL;
+#endif
+		if (p && p[0] == '\\' && (strcmp(p, "/../") || strcmp(p, "\\"))) {
+			snprintf(home_file, sizeof(home_file), "%s/%s", p, RC_FILE);
+			ParseRCFile(home_file, keys);
+		} else {
+			fprintf(stderr, "Invalid HOME directory: %s\n", p);
+		}
 	}
 }
 

--- a/src/rcfiles.c
+++ b/src/rcfiles.c
@@ -33,6 +33,14 @@
 # include <getopt.h>
 #endif
 
+#ifdef HAVE_REALPATH && HAVE_REALPATH
+# ifdef HAVE_LIMITS_H
+#  include <limits.h>
+# endif
+# ifdef HAVE_STDLIB_H
+#  include <stdlib.h>
+# endif
+#endif
 
 /*******************************************************************************\
 |* AddRcKey                                                                     |

--- a/src/rcfiles.c
+++ b/src/rcfiles.c
@@ -148,10 +148,10 @@ void LoadRCFile(rckeys *keys)
 	p = getenv("HOME");
 	if (p) {
 		snprintf(home_file, sizeof(home_file), "%s/%s", p, RC_FILE);
+		ParseRCFile(home_file, keys);
 	} else {
 		home_file[0] = '\0'; // Ensure home_file is empty if HOME is not set
 	}
-	ParseRCFile(home_file, keys);
 }
 
 /*******************************************************************************\

--- a/src/rcfiles.c
+++ b/src/rcfiles.c
@@ -157,17 +157,23 @@ void LoadRCFile(rckeys *keys)
 	home_file[0] = '\0';
 	if (p) {
 #ifdef HAVE_REALPATH && HAVE_REALPATH
-		char resolved_path[PATH_MAX];
-		if (realpath(p, resolved_path))
+		char	resolved_path[PATH_MAX];
+		if (realpath(p, resolved_path)) {
 			p = resolved_path;
-		else
+		} else {
+			fprintf(stderr, "Invalid or unsafe HOME directory: %s\n", p);
 			p = NULL;
+		}
+
+		if (p)
 #endif
-		if (p && p[0] == '\\' && (strcmp(p, "/../") || strcmp(p, "\\"))) {
+		/* Sanity-check that HOME dir is absolute, does not have
+  		 * any escape chars and/or dot-dot upstaging */
+		if (p[0] == '/' && (strcmp(p, "/../") || strcmp(p, "\\"))) {
 			snprintf(home_file, sizeof(home_file), "%s/%s", p, RC_FILE);
 			ParseRCFile(home_file, keys);
 		} else {
-			fprintf(stderr, "Invalid HOME directory: %s\n", p);
+			fprintf(stderr, "Invalid or unsafe HOME directory: %s\n", p);
 		}
 	}
 }


### PR DESCRIPTION
Potential fix for [https://github.com/networkupstools/wmnut/security/code-scanning/35](https://github.com/networkupstools/wmnut/security/code-scanning/35)

To fix the issue, replace the unsafe `sprintf` call with `snprintf`, which allows specifying the maximum size of the destination buffer. This ensures that the write operation does not exceed the size of `home_file`. Specifically:
1. Use `snprintf` instead of `sprintf` on line 149.
2. Pass the size of the `home_file` buffer (128 bytes) as the second argument to `snprintf`.
3. Ensure that the code handles cases where the resulting string is truncated due to exceeding the buffer size.

The fix will be applied in the `LoadRCFile` function in `src/rcfiles.c`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
