### PR TITLE
Introduce NUT_PATH_MAX and revise array limit/sizeof where numbers were used

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -193,8 +193,8 @@ myLIBS="$LIBS"
 CFLAGS="$NUT_CFLAGS"
 LIBS="$NUT_LIBS"
 AC_CHECK_FUNCS(upscli_strerror upscli_str_contains_token)
-CFLAGS="$CFLAGS"
-LIBS="$LIBS"
+CFLAGS="$myCFLAGS"
+LIBS="$myLIBS"
 
 dnl Checks for typedefs, structures, and compiler characteristics.
 

--- a/configure.ac
+++ b/configure.ac
@@ -60,7 +60,7 @@ AC_CHECK_DECLS(realpath, [], [],
 #endif
 ])
 
-AC_CHECK_HEADERS(unistd.h stdio.h string.h signal.h ctype.h stdarg.h X11/X.h X11/Xlib.h X11/xpm.h X11/extensions/shape.h X11/Xatom.h)
+AC_CHECK_HEADERS(unistd.h stdio.h string.h signal.h ctype.h stdarg.h sys/time.h time.h X11/X.h X11/Xlib.h X11/xpm.h X11/extensions/shape.h X11/Xatom.h)
 
 dnl ===========================
 dnl Checks for standard library functions.

--- a/configure.ac
+++ b/configure.ac
@@ -19,6 +19,13 @@ dnl
 dnl ISODATE="`date +%Y-%m-%d`"
 dnl AC_SUBST(ISODATE)
 
+dnl FIXME: ...or check if a newer C standard is enabled
+AC_MSG_CHECKING([whether we build in C99/GNU99 mode])
+AS_CASE(["${CC}${CFLAGS}"],
+	[*99*], [AC_MSG_RESULT(yes)],
+	[AC_MSG_RESULT(no)
+	 AC_MSG_WARN([If your build fails due to standard system header method and type names, or ISO C90 warnings, make sure you build in C99 mode (or newer) e.g. by passing '-std=gnu99' to GCC/CLANG])
+	])
 
 dnl
 dnl Specify paths to look for libraries and headers
@@ -30,6 +37,37 @@ AC_ARG_WITH(libs-from,
 AC_ARG_WITH(incs-from,
 	[  --with-incs-from        pass compiler flags to look for header files],
 	[inc_search_path="$withval $inc_search_path"])
+
+dnl ===========================
+dnl Checks for standard header files.
+dnl ===========================
+AC_HEADER_SYS_WAIT
+
+AC_CHECK_HEADER([limits.h],
+	[AC_DEFINE([HAVE_LIMITS_H], [1],
+		[Define to 1 if you have <limits.h>.])])
+
+AC_CHECK_HEADER([stdlib.h],
+	[AC_DEFINE([HAVE_STDLIB_H], [1],
+		[Define to 1 if you have <stdlib.h>.])])
+
+AC_CHECK_DECLS(realpath, [], [],
+[#ifdef HAVE_LIMITS_H
+# include <limits.h>
+#endif
+#ifdef HAVE_STDLIB_H
+# include <stdlib.h>
+#endif
+])
+
+AC_CHECK_HEADERS(unistd.h stdio.h string.h signal.h ctype.h stdarg.h X11/X.h X11/Xlib.h X11/xpm.h X11/extensions/shape.h X11/Xatom.h)
+
+dnl ===========================
+dnl Checks for standard library functions.
+dnl ===========================
+dnl AC_FUNC_MALLOC
+
+AC_CHECK_FUNCS(usleep snprintf strdup)
 
 dnl ===========================
 dnl check for getopt specifics.
@@ -172,38 +210,6 @@ AC_SUBST(HEADER_SEARCH_PATH)
 AC_SUBST(NUT_HEADER)
 AC_SUBST(NUT_LIB)
 AC_SUBST(NUT_VERSION)
-
-dnl Checks for header files.
-AC_HEADER_SYS_WAIT
-
-AC_CHECK_HEADER([limits.h],
-    [AC_DEFINE([HAVE_LIMITS_H], [1],
-        [Define to 1 if you have <limits.h>.])])
-
-AC_CHECK_HEADER([stdlib.h],
-    [AC_DEFINE([HAVE_STDLIB_H], [1],
-        [Define to 1 if you have <stdlib.h>.])])
-
-AC_CHECK_DECLS(realpath, [], [],
-[#ifdef HAVE_LIMITS_H
-# include <limits.h>
-#endif
-#ifdef HAVE_STDLIB_H
-# include <stdlib.h>
-#endif
-])
-
-AC_CHECK_HEADERS(unistd.h stdio.h string.h signal.h ctype.h stdarg.h X11/X.h X11/Xlib.h X11/xpm.h X11/extensions/shape.h X11/Xatom.h)
-
-dnl Checks for library functions.
-dnl AC_FUNC_MALLOC
-
-AC_MSG_CHECKING([whether we build in C99/GNU99 mode])
-AS_CASE(["${CC}${CFLAGS}"],
-	[*99*], [AC_MSG_RESULT(yes)],
-	[AC_MSG_RESULT(no)
-	 AC_MSG_WARN([If your build fails due to standard system header method and type names, or ISO C90 warnings, make sure you build in C99 mode (or newer)])
-	])
 
 AC_CONFIG_FILES([
 	Makefile

--- a/configure.ac
+++ b/configure.ac
@@ -133,7 +133,11 @@ AC_ARG_ENABLE(debug,
 	[  --enable-debug          turn on debugging [default=no]],, enable_debug=no)
 
 if test x"$enable_debug" = xyes; then
-	DBGFLAGS="-Wall -g -ansi -pedantic"
+	DBGFLAGS="-Wall -g -pedantic"
+
+	dnl Avoid "-ansi": it requires C89 which the modern system
+	dnl headers are not compatible with generally
+	dnl DBGFLAGS="$DBGFLAGS -ansi"
 fi
 
 AC_ARG_ENABLE(Werror,

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -2,6 +2,7 @@ bin_PROGRAMS = wmnut
 
 wmnut_SOURCES = \
 	wmnut.c \
+	wmnut-common.h \
 	wmnut.h \
 	wmgeneral.c \
 	wmgeneral.h \

--- a/src/rcfiles.c
+++ b/src/rcfiles.c
@@ -35,7 +35,7 @@
 # include <getopt.h>
 #endif
 
-#ifdef HAVE_REALPATH && HAVE_REALPATH
+#if (defined HAVE_REALPATH) && HAVE_REALPATH
 # ifdef HAVE_LIMITS_H
 #  include <limits.h>
 # endif
@@ -158,7 +158,7 @@ void LoadRCFile(rckeys *keys)
 	p = getenv("HOME");
 	home_file[0] = '\0';
 	if (p) {
-#ifdef HAVE_REALPATH && HAVE_REALPATH
+#if (defined HAVE_REALPATH) && HAVE_REALPATH
 		char	resolved_path[NUT_PATH_MAX];
 		if (realpath(p, resolved_path)) {
 			p = resolved_path;
@@ -170,7 +170,7 @@ void LoadRCFile(rckeys *keys)
 		if (p)
 #endif
 		/* Sanity-check that HOME dir is absolute, does not have
-  		 * any escape chars and/or dot-dot upstaging */
+		 * any escape chars and/or dot-dot upstaging */
 		if (p[0] == '/' && (strcmp(p, "/../") || strcmp(p, "\\"))) {
 			snprintf(home_file, sizeof(home_file), "%s/%s", p, RC_FILE);
 			ParseRCFile(home_file, keys);

--- a/src/rcfiles.c
+++ b/src/rcfiles.c
@@ -92,7 +92,7 @@ void ParseRCFile(const char *filename, rckeys *keys)
 #ifdef DEBUG
 		printf("Opening rc file %s\n", filename);
 #endif
-		while (fgets(temp, 128, fp)) {
+		while (fgets(temp, sizeof(temp), fp)) {
 			if (temp[0] != '#') {
 				key = 0;
 				while (key >= 0 && keys[key].label) {

--- a/src/rcfiles.c
+++ b/src/rcfiles.c
@@ -29,6 +29,7 @@
 #include <unistd.h>
 #include <stdlib.h>
 #include "wmgeneral.h"
+#include "wmnut.h"
 
 #ifdef HAVE_GETOPT_LONG
 # include <getopt.h>
@@ -145,7 +146,7 @@ void ParseRCFile(const char *filename, rckeys *keys)
 \*******************************************************************************/
 void LoadRCFile(rckeys *keys)
 {
-	char	home_file[128];	/* FIXME with PATH_MAX or equivalents, portably */
+	char	home_file[NUT_PATH_MAX];
 	char	*p;
 
 #ifdef DEBUG
@@ -158,7 +159,7 @@ void LoadRCFile(rckeys *keys)
 	home_file[0] = '\0';
 	if (p) {
 #ifdef HAVE_REALPATH && HAVE_REALPATH
-		char	resolved_path[PATH_MAX];
+		char	resolved_path[NUT_PATH_MAX];
 		if (realpath(p, resolved_path)) {
 			p = resolved_path;
 		} else {

--- a/src/rcfiles.c
+++ b/src/rcfiles.c
@@ -24,12 +24,17 @@
  */
 
 #include "config.h"
+/* May be generated without include header guards */
+#ifndef CONFIG_H_INCLUDED
+# define CONFIG_H_INCLUDED
+#endif	/* CONFIG_H_INCLUDED */
+
+#include "wmgeneral.h"
+#include "wmnut.h"
 
 #include <stdio.h>
 #include <unistd.h>
 #include <stdlib.h>
-#include "wmgeneral.h"
-#include "wmnut.h"
 
 #ifdef HAVE_GETOPT_LONG
 # include <getopt.h>

--- a/src/rcfiles.c
+++ b/src/rcfiles.c
@@ -23,18 +23,8 @@
  *
  */
 
-#include "config.h"
-/* May be generated without include header guards */
-#ifndef CONFIG_H_INCLUDED
-# define CONFIG_H_INCLUDED
-#endif	/* CONFIG_H_INCLUDED */
-
+#include "wmnut-common.h"	/* includes config.h */
 #include "wmgeneral.h"
-#include "wmnut.h"
-
-#include <stdio.h>
-#include <unistd.h>
-#include <stdlib.h>
 
 #ifdef HAVE_GETOPT_LONG
 # include <getopt.h>

--- a/src/rcfiles.c
+++ b/src/rcfiles.c
@@ -23,11 +23,12 @@
  *
  */
 
+#include "config.h"
+
 #include <stdio.h>
 #include <unistd.h>
 #include <stdlib.h>
 #include "wmgeneral.h"
-#include "config.h"
 
 #ifdef HAVE_GETOPT_LONG
 # include <getopt.h>

--- a/src/wmgeneral.h
+++ b/src/wmgeneral.h
@@ -2,8 +2,14 @@
 #define WMGENERAL_H_INCLUDED
 
 #ifdef HAVE_CONFIG_H
-# include "config.h"
-#endif
+/* Generated without include header guards */
+# ifndef CONFIG_H_INCLUDED
+#  include "config.h"
+#  ifndef CONFIG_H_INCLUDED
+#   define CONFIG_H_INCLUDED
+#  endif	/* CONFIG_H_INCLUDED */
+# endif	/* CONFIG_H_INCLUDED */
+#endif	/* HAVE_CONFIG_H */
 
 /* X11 includes */
 #include <X11/X.h>

--- a/src/wmnut-common.h
+++ b/src/wmnut-common.h
@@ -1,0 +1,88 @@
+/*
+ * wmnut-common.h  -- Header file for WMNUT with common includes and definitions
+ *
+ * Copyright (C)
+ *   2002 - 2012  Arnaud Quette <arnaud.quette@free.fr>
+ *   2022 - 2025  Jim Klimov <jimklimov+nut@gmail.com>
+ *          2024  desertwitch <dezertwitsh@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program (see the file COPYING); if not, write to the
+ * Free Software Foundation, Inc.,
+ * 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA
+ *
+ */
+
+#ifndef WMNUT_COMMON_H_INCLUDED
+#define WMNUT_COMMON_H_INCLUDED
+
+#ifdef HAVE_CONFIG_H
+/* May be generated without include header guards */
+# ifndef CONFIG_H_INCLUDED
+#  include "config.h"
+#  ifndef CONFIG_H_INCLUDED
+#   define CONFIG_H_INCLUDED
+#  endif	/* CONFIG_H_INCLUDED */
+# endif	/* CONFIG_H_INCLUDED */
+#endif	/* HAVE_CONFIG_H */
+
+/* standard system includes */
+#ifdef FreeBSD
+# include <err.h>
+# include <sys/file.h>
+#endif
+
+#include <stdio.h>
+#include <unistd.h>
+#include <stdlib.h>
+#include <string.h>
+#include <signal.h>
+
+#if HAVE_LIMITS_H
+# include <limits.h>
+#endif
+
+/* nut and wmnut includes */
+#include <upsclient.h>
+#if defined HAVE_UPSCLI_STR_CONTAINS_TOKEN && HAVE_UPSCLI_STR_CONTAINS_TOKEN
+# define	STR_CONTAINS_TOKEN(haystack, needle)	upscli_str_contains_token(haystack, needle)
+#else
+# define	STR_CONTAINS_TOKEN(haystack, needle)	strstr(haystack, needle)
+#endif
+
+#define SMALLBUF	256
+#define LARGEBUF	1024
+
+/* Portable max path length, may be or not be defined in NUT headers too */
+#ifndef NUT_PATH_MAX
+# define NUT_PATH_MAX	SMALLBUF
+# if (defined(PATH_MAX)) && PATH_MAX > NUT_PATH_MAX
+#  undef NUT_PATH_MAX
+#  define NUT_PATH_MAX	PATH_MAX
+# endif
+# if (defined(MAX_PATH)) && MAX_PATH > NUT_PATH_MAX
+/* PATH_MAX is the POSIX equivalent for Microsoft's MAX_PATH */
+#  undef NUT_PATH_MAX
+#  define NUT_PATH_MAX	MAX_PATH
+# endif
+# if (defined(UNIX_PATH_MAX)) && UNIX_PATH_MAX > NUT_PATH_MAX
+#  undef NUT_PATH_MAX
+#  define NUT_PATH_MAX	UNIX_PATH_MAX
+# endif
+# if (defined(MAXPATHLEN)) && MAXPATHLEN > NUT_PATH_MAX
+#  undef NUT_PATH_MAX
+#  define NUT_PATH_MAX	MAXPATHLEN
+# endif
+#endif	/* !NUT_PATH_MAX */
+
+#endif	/* WMNUT_H_COMMON_INCLUDED */

--- a/src/wmnut.c
+++ b/src/wmnut.c
@@ -28,13 +28,7 @@
  *
  */
 
-#include "config.h"
-/* May be generated without include header guards */
-#ifndef CONFIG_H_INCLUDED
-# define CONFIG_H_INCLUDED
-#endif	/* CONFIG_H_INCLUDED */
-
-#include "wmnut.h"
+#include "wmnut.h"	/* includes wmnut-common.h and config.h */
 
 #include <stdint.h>	/* For size_t, may require C99+ */
 

--- a/src/wmnut.c
+++ b/src/wmnut.c
@@ -738,7 +738,7 @@ int AddHost(char *hostname)
 	const char	*query[4];
 	size_t	numq, numa;
 	char	**answer;
-	char	newhostname[32];
+	char	newhostname[LARGEBUF];
 	UPSCONN_t	ups;
 
 	DEBUGOUT("AddHost(%s)\n", hostname);

--- a/src/wmnut.c
+++ b/src/wmnut.c
@@ -33,9 +33,6 @@
 #include <stdint.h>	/* For size_t, may require C99+ */
 #include "wmnut.h"
 
-/* defines */
-#define LARGEBUF	1024
-
 void	ParseCMDLine(int argc, char *argv[]);
 void	InitHosts(void);
 int	AddHost(char *hostname);

--- a/src/wmnut.c
+++ b/src/wmnut.c
@@ -29,9 +29,14 @@
  */
 
 #include "config.h"
+/* May be generated without include header guards */
+#ifndef CONFIG_H_INCLUDED
+# define CONFIG_H_INCLUDED
+#endif	/* CONFIG_H_INCLUDED */
+
+#include "wmnut.h"
 
 #include <stdint.h>	/* For size_t, may require C99+ */
-#include "wmnut.h"
 
 void	ParseCMDLine(int argc, char *argv[]);
 void	InitHosts(void);

--- a/src/wmnut.c
+++ b/src/wmnut.c
@@ -28,6 +28,8 @@
  *
  */
 
+#include "config.h"
+
 #include <stdint.h>	/* For size_t, may require C99+ */
 #include "wmnut.h"
 

--- a/src/wmnut.c
+++ b/src/wmnut.c
@@ -70,7 +70,7 @@ ups_info	*CurHost;
 /* List of all UPSs monitored */
 nut_info	Hosts;
 
-rckeys	wmnut_keys[13];
+rckeys	wmnut_keys[13];	/* This many fields are populated in main() below */
 
 /* Debug macros */
 #define DEBUGOUT(...)	{ if (Verbose) fprintf(stdout, __VA_ARGS__); }

--- a/src/wmnut.h
+++ b/src/wmnut.h
@@ -26,45 +26,12 @@
 #ifndef WMNUT_H_INCLUDED
 #define WMNUT_H_INCLUDED
 
-#ifdef HAVE_CONFIG_H
-/* Generated without include header guards */
-# ifndef CONFIG_H_INCLUDED
-#  include "config.h"
-#  ifndef CONFIG_H_INCLUDED
-#   define CONFIG_H_INCLUDED
-#  endif	/* CONFIG_H_INCLUDED */
-# endif	/* CONFIG_H_INCLUDED */
-#endif	/* HAVE_CONFIG_H */
-
-/* standard system includes */
-#ifdef FreeBSD
-# include <err.h>
-# include <sys/file.h>
-#endif
-
-#include <stdio.h>
-#include <unistd.h>
-#include <stdlib.h>
-#include <string.h>
-#include <signal.h>
-
-#if HAVE_LIMITS_H
-# include <limits.h>
-#endif
+#include "wmnut-common.h"
+#include "wmgeneral.h"
 
 /* X11 includes */
 #include <X11/X.h>
 #include <X11/xpm.h>
-
-/* nut and wmnut includes */
-#include <upsclient.h>
-#if defined HAVE_UPSCLI_STR_CONTAINS_TOKEN && HAVE_UPSCLI_STR_CONTAINS_TOKEN
-# define	STR_CONTAINS_TOKEN(haystack, needle)	upscli_str_contains_token(haystack, needle)
-#else
-# define	STR_CONTAINS_TOKEN(haystack, needle)	strstr(haystack, needle)
-#endif
-
-#include "wmgeneral.h"
 
 /* pixmaps */
 #include "wmnut_master.xpm"
@@ -72,31 +39,6 @@
 #include "wmnut_mask.xbm"
 
 #define DELAY 10000L		/* Delay between refreshes (in microseconds) */
-
-#define SMALLBUF	256
-#define LARGEBUF	1024
-
-/* Portable max path length, may be or not be defined in NUT headers too */
-#ifndef NUT_PATH_MAX
-# define NUT_PATH_MAX	SMALLBUF
-# if (defined(PATH_MAX)) && PATH_MAX > NUT_PATH_MAX
-#  undef NUT_PATH_MAX
-#  define NUT_PATH_MAX	PATH_MAX
-# endif
-# if (defined(MAX_PATH)) && MAX_PATH > NUT_PATH_MAX
-/* PATH_MAX is the POSIX equivalent for Microsoft's MAX_PATH */
-#  undef NUT_PATH_MAX
-#  define NUT_PATH_MAX	MAX_PATH
-# endif
-# if (defined(UNIX_PATH_MAX)) && UNIX_PATH_MAX > NUT_PATH_MAX
-#  undef NUT_PATH_MAX
-#  define NUT_PATH_MAX	UNIX_PATH_MAX
-# endif
-# if (defined(MAXPATHLEN)) && MAXPATHLEN > NUT_PATH_MAX
-#  undef NUT_PATH_MAX
-#  define NUT_PATH_MAX	MAXPATHLEN
-# endif
-#endif	/* !NUT_PATH_MAX */
 
 /* Communication status definition */
 

--- a/src/wmnut.h
+++ b/src/wmnut.h
@@ -23,6 +23,9 @@
  *
  */
 
+#ifndef WMNUT_H_INCLUDED
+#define WMNUT_H_INCLUDED
+
 #ifdef HAVE_CONFIG_H
 # include "config.h"
 #endif
@@ -168,3 +171,5 @@ typedef struct nut_info {
 	int	curhosts_number;	/* number of the currently displayed host */
 	ups_info	*Ups_list[MAX_HOSTS_NUMBER];	/* list of monitored UPSs (from 1 to 9) */
 } nut_info;
+
+#endif	/* WMNUT_H_INCLUDED */

--- a/src/wmnut.h
+++ b/src/wmnut.h
@@ -39,6 +39,10 @@
 #include <string.h>
 #include <signal.h>
 
+#if HAVE_LIMITS_H
+# include <limits.h>
+#endif
+
 /* X11 includes */
 #include <X11/X.h>
 #include <X11/xpm.h>
@@ -62,6 +66,28 @@
 
 #define SMALLBUF	256
 #define LARGEBUF	1024
+
+/* Portable max path length, may be or not be defined in NUT headers too */
+#ifndef NUT_PATH_MAX
+# define NUT_PATH_MAX	SMALLBUF
+# if (defined(PATH_MAX)) && PATH_MAX > NUT_PATH_MAX
+#  undef NUT_PATH_MAX
+#  define NUT_PATH_MAX	PATH_MAX
+# endif
+# if (defined(MAX_PATH)) && MAX_PATH > NUT_PATH_MAX
+/* PATH_MAX is the POSIX equivalent for Microsoft's MAX_PATH */
+#  undef NUT_PATH_MAX
+#  define NUT_PATH_MAX	MAX_PATH
+# endif
+# if (defined(UNIX_PATH_MAX)) && UNIX_PATH_MAX > NUT_PATH_MAX
+#  undef NUT_PATH_MAX
+#  define NUT_PATH_MAX	UNIX_PATH_MAX
+# endif
+# if (defined(MAXPATHLEN)) && MAXPATHLEN > NUT_PATH_MAX
+#  undef NUT_PATH_MAX
+#  define NUT_PATH_MAX	MAXPATHLEN
+# endif
+#endif	/* !NUT_PATH_MAX */
 
 /* Communication status definition */
 

--- a/src/wmnut.h
+++ b/src/wmnut.h
@@ -27,8 +27,14 @@
 #define WMNUT_H_INCLUDED
 
 #ifdef HAVE_CONFIG_H
-# include "config.h"
-#endif
+/* Generated without include header guards */
+# ifndef CONFIG_H_INCLUDED
+#  include "config.h"
+#  ifndef CONFIG_H_INCLUDED
+#   define CONFIG_H_INCLUDED
+#  endif	/* CONFIG_H_INCLUDED */
+# endif	/* CONFIG_H_INCLUDED */
+#endif	/* HAVE_CONFIG_H */
 
 /* standard system includes */
 #ifdef FreeBSD


### PR DESCRIPTION
Improve maintainability and portability, reduce magic.

Rectify use of `config.h`.

Found some bugs in autoconf scripts, released for 0.71 and fixed here.