### PR TITLE
src/wmnut.c: CleanHosts(): free upsname/hostname strings if set

### DIFF
--- a/src/rcfiles.c
+++ b/src/rcfiles.c
@@ -73,7 +73,39 @@ void AddRcKey(rckeys *key, const char *label, int type, void *var) {
 	}
 }
 
-/* TODO : void FreeRcKeys(rckeys *key)*/
+/*******************************************************************************\
+|* FreeRcKeyData                                                                |
+\*******************************************************************************/
+void FreeRcKeyData(rckeys *key) {
+	if (!key)
+		return;
+
+	if (key->label) {
+		free(key->label);
+		key->label = NULL;
+	}
+
+	if (key->type == TYPE_STRING && key->var.str) {
+		free(key->var.str);
+		key->var.str = NULL;
+	}
+}
+
+/*******************************************************************************\
+|* FreeRcKeys                                                                   |
+\*******************************************************************************/
+void FreeRcKeys(rckeys *keys) {
+	/* NOTE: Assumes it accepts an array to free() its elements;
+	 * if this array itself is dynamic, caller should free() it */
+	int	keynum;
+
+	if (!keys)
+		return;
+
+	for (keynum = 0; keys[keynum].type != TYPE_NULL; keynum++) {
+		FreeRcKeyData(&keys[keynum]);
+	}
+}
 
 /*******************************************************************************\
 |* ParseRCFile                                                                  |

--- a/src/wmgeneral.h
+++ b/src/wmgeneral.h
@@ -88,6 +88,8 @@ void copyXBMArea(int, int, int, int, int, int);
 void setMaskXY(int, int);
 
 void AddRcKey(rckeys *key, const char *label, int type, void *var);
+void FreeRcKeyData(rckeys *key);
+void FreeRcKeys(rckeys *key);	/* Free an array starting from given element and up to TYPE_NULL entry */
 void ParseRCFile(const char *filename, rckeys *keys);
 void ParseCMDLine(int argc, char *argv[]);
 void LoadRCFile(rckeys *keys);

--- a/src/wmnut.c
+++ b/src/wmnut.c
@@ -210,6 +210,10 @@ void get_ups_info(void)
 	return;
 }
 
+static void exit_cleanup(void) {
+	FreeRcKeys(wmnut_keys);
+}
+
 int main(int argc, char *argv[]) {
 	int		time_left, hour_left, min_left;
 	int		i, m, n, nMax, k, Toggle = OFF;
@@ -244,6 +248,8 @@ int main(int argc, char *argv[]) {
 	AddRcKey(&wmnut_keys[10], "Verbose", TYPE_BOOL, &Verbose);
 	AddRcKey(&wmnut_keys[11], "WithDrawn", TYPE_BOOL, &WithDrawn);
 	AddRcKey(&wmnut_keys[12], NULL, TYPE_NULL, NULL);
+
+	atexit(exit_cleanup);
 
 	/* Initialise host structure */
 	InitHosts();

--- a/src/wmnut.c
+++ b/src/wmnut.c
@@ -719,6 +719,11 @@ void CleanHosts(void)
 		upscli_disconnect ( &Hosts.Ups_list[i - 1]->connexion );
 
 		if ( Hosts.Ups_list[i - 1] != NULL ) {
+			if ( Hosts.Ups_list[i - 1]->upsname )
+				free ( Hosts.Ups_list[i - 1]->upsname );
+			if ( Hosts.Ups_list[i - 1]->hostname )
+				free ( Hosts.Ups_list[i - 1]->hostname );
+
 			free ( Hosts.Ups_list[i - 1] );
 			Hosts.Ups_list[i - 1] = NULL;
 		}

--- a/src/wmnut.c
+++ b/src/wmnut.c
@@ -68,7 +68,8 @@ ups_info	*CurHost;
 /* List of all UPSs monitored */
 nut_info	Hosts;
 
-rckeys	wmnut_keys[13];	/* This many fields are populated in main() below */
+#define WMNUT_KEYS_AMOUNT	13	/* This many fields are populated in main() below */
+rckeys	wmnut_keys[WMNUT_KEYS_AMOUNT];
 
 /* Debug macros */
 #define DEBUGOUT(...)	{ if (Verbose) fprintf(stdout, __VA_ARGS__); }
@@ -264,8 +265,8 @@ int main(int argc, char *argv[]) {
 	 * Note that it overrides RCFiles params */
 	ParseCMDLine(argc, argv);
 
-	for (i = 0; i < 12; i++ ) {
-		switch(wmnut_keys[i].type) {
+	for (i = 0; i < (WMNUT_KEYS_AMOUNT - 1); i++ ) {
+		switch (wmnut_keys[i].type) {
 			case TYPE_STRING :
 				DEBUGOUT("%s = %s\n", wmnut_keys[i].label, wmnut_keys[i].var.str);
 				break;
@@ -277,6 +278,7 @@ int main(int argc, char *argv[]) {
 				DEBUGOUT("%s = %f\n", wmnut_keys[i].label, (float) *wmnut_keys[i].var.floater);
 				break;
 			case TYPE_NULL:
+				DEBUGOUT("wmnut_keys[%d] is a sentinel entry (TYPE_NULL)", i);
 				break;
 		}
 	}


### PR DESCRIPTION
Found by valgrind. It also complains about:
```
==1665809== 6 bytes in 1 blocks are definitely lost in loss record 5 of 69
==1665809==    at 0x4848899: malloc (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==1665809==    by 0x48A2516: XStringListToTextProperty (in /usr/lib/x86_64-linux-gnu/libX11.so.6.4.0)
==1665809==    by 0x10F09F: openXwindow (wmgeneral.c:354)
==1665809==    by 0x10CBA0: main (wmnut.c:308)
```

where line 354 is `if (XStringListToTextProperty(&wname, 1, &name) == 0) { ...`

...but I did not find if any `XFree()` method applies to an `XTextProperty` instance (its `value` property?)

According to a larger query with `LD_LIBRARY_PATH=~/nut-inst/usr/local/ups/lib valgrind --leak-check=full  --leak-check=full --show-leak-kinds=all ./src/wmnut &` there are many "reachable" blocks. Most are due to openssl via libupsclient; some are due to lack of a `FreeRcKeys()`method...

A few more are with X11 (pixmap=>bitmap):
```
==1668647==
==1668647== 64 bytes in 1 blocks are still reachable in loss record 39 of 69
==1668647==    at 0x4848899: malloc (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==1668647==    by 0x48A0126: _XrmInternalStringToQuark (in /usr/lib/x86_64-linux-gnu/libX11.so.6.4.0)
==1668647==    by 0x48B3CB3: XrmInitialize (in /usr/lib/x86_64-linux-gnu/libX11.so.6.4.0)
==1668647==    by 0x4891B5B: ??? (in /usr/lib/x86_64-linux-gnu/libX11.so.6.4.0)
==1668647==    by 0x4891DC5: XGetDefault (in /usr/lib/x86_64-linux-gnu/libX11.so.6.4.0)
==1668647==    by 0x5567A12: _XcursorGetDisplayInfo (in /usr/lib/x86_64-linux-gnu/libXcursor.so.1.0.2)
==1668647==    by 0x5567B4C: XcursorSupportsARGB (in /usr/lib/x86_64-linux-gnu/libXcursor.so.1.0.2)
==1668647==    by 0x556AC94: XcursorNoticeCreateBitmap (in /usr/lib/x86_64-linux-gnu/libXcursor.so.1.0.2)
==1668647==    by 0x488A380: XCreatePixmap (in /usr/lib/x86_64-linux-gnu/libX11.so.6.4.0)
==1668647==    by 0x488EA02: XCreateBitmapFromData (in /usr/lib/x86_64-linux-gnu/libX11.so.6.4.0)
==1668647==    by 0x10F132: openXwindow (wmgeneral.c:376)
==1668647==    by 0x10CBA0: main (wmnut.c:308)
...
==1668647==
==1668647== 4,096 bytes in 1 blocks are still reachable in loss record 68 of 69
==1668647==    at 0x484DA83: calloc (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==1668647==    by 0x489FF8A: _XrmInternalStringToQuark (in /usr/lib/x86_64-linux-gnu/libX11.so.6.4.0)
==1668647==    by 0x48B3CB3: XrmInitialize (in /usr/lib/x86_64-linux-gnu/libX11.so.6.4.0)
==1668647==    by 0x4891B5B: ??? (in /usr/lib/x86_64-linux-gnu/libX11.so.6.4.0)
==1668647==    by 0x4891DC5: XGetDefault (in /usr/lib/x86_64-linux-gnu/libX11.so.6.4.0)
==1668647==    by 0x5567A12: _XcursorGetDisplayInfo (in /usr/lib/x86_64-linux-gnu/libXcursor.so.1.0.2)
==1668647==    by 0x5567B4C: XcursorSupportsARGB (in /usr/lib/x86_64-linux-gnu/libXcursor.so.1.0.2)
==1668647==    by 0x556AC94: XcursorNoticeCreateBitmap (in /usr/lib/x86_64-linux-gnu/libXcursor.so.1.0.2)
==1668647==    by 0x488A380: XCreatePixmap (in /usr/lib/x86_64-linux-gnu/libX11.so.6.4.0)
==1668647==    by 0x488EA02: XCreateBitmapFromData (in /usr/lib/x86_64-linux-gnu/libX11.so.6.4.0)
==1668647==    by 0x10F132: openXwindow (wmgeneral.c:376)
==1668647==    by 0x10CBA0: main (wmnut.c:308)
==1668647==
==1668647== 8,176 bytes in 1 blocks are still reachable in loss record 69 of 69
==1668647==    at 0x4848899: malloc (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==1668647==    by 0x489ED95: ??? (in /usr/lib/x86_64-linux-gnu/libX11.so.6.4.0)
==1668647==    by 0x48A0105: _XrmInternalStringToQuark (in /usr/lib/x86_64-linux-gnu/libX11.so.6.4.0)
==1668647==    by 0x48B3CB3: XrmInitialize (in /usr/lib/x86_64-linux-gnu/libX11.so.6.4.0)
==1668647==    by 0x4891B5B: ??? (in /usr/lib/x86_64-linux-gnu/libX11.so.6.4.0)
==1668647==    by 0x4891DC5: XGetDefault (in /usr/lib/x86_64-linux-gnu/libX11.so.6.4.0)
==1668647==    by 0x5567A12: _XcursorGetDisplayInfo (in /usr/lib/x86_64-linux-gnu/libXcursor.so.1.0.2)
==1668647==    by 0x5567B4C: XcursorSupportsARGB (in /usr/lib/x86_64-linux-gnu/libXcursor.so.1.0.2)
==1668647==    by 0x556AC94: XcursorNoticeCreateBitmap (in /usr/lib/x86_64-linux-gnu/libXcursor.so.1.0.2)
==1668647==    by 0x488A380: XCreatePixmap (in /usr/lib/x86_64-linux-gnu/libX11.so.6.4.0)
==1668647==    by 0x488EA02: XCreateBitmapFromData (in /usr/lib/x86_64-linux-gnu/libX11.so.6.4.0)
==1668647==    by 0x10F132: openXwindow (wmgeneral.c:376)

```